### PR TITLE
Amortization table data integrity

### DIFF
--- a/src/components/mortgage-investment-compare/amortization-table.js
+++ b/src/components/mortgage-investment-compare/amortization-table.js
@@ -161,11 +161,11 @@ const AmortizationTable = props => {
                 <td>{toUSD(shorter.pmt)}</td>
                 <td>{toUSD(shorter.investmentPMT)}</td>
                 <td>{toUSD(shorter.loanAmt)}</td>
-                <td>{toUSD(shorter.investmentAmount)}</td>
+                <td>{toUSD(shorter.investmentAmt)}</td>
                 <td>{toUSD(longer.pmt)}</td>
                 <td>{toUSD(longer.investmentPMT)}</td>
                 <td>{toUSD(longer.loanAmt)}</td>
-                <td>{toUSD(longer.investmentAmount)}</td>
+                <td>{toUSD(longer.investmentAmt)}</td>
               </tr>
             )
           })}

--- a/src/components/mortgage-investment-compare/amortization-table.js
+++ b/src/components/mortgage-investment-compare/amortization-table.js
@@ -140,14 +140,14 @@ const AmortizationTable = props => {
                 }
               >
                 <td>Year {year + 1}</td>
-                <td>{toUSD(-shorter.pmt)}</td>
-                <td>{toUSD(-shorter.investmentPMT)}</td>
+                <td>{toUSD(shorter.pmt)}</td>
+                <td>{toUSD(shorter.investmentPMT)}</td>
                 <td>{toUSD(shorter.loanAmt)}</td>
-                <td>{toUSD(-shorter.investmentAmount)}</td>
-                <td>{toUSD(-longer.pmt)}</td>
-                <td>{toUSD(-longer.investmentPMT)}</td>
+                <td>{toUSD(shorter.investmentAmount)}</td>
+                <td>{toUSD(longer.pmt)}</td>
+                <td>{toUSD(longer.investmentPMT)}</td>
                 <td>{toUSD(longer.loanAmt)}</td>
-                <td>{toUSD(-longer.investmentAmount)}</td>
+                <td>{toUSD(longer.investmentAmount)}</td>
               </tr>
             )
           })}

--- a/src/components/mortgage-investment-compare/index.js
+++ b/src/components/mortgage-investment-compare/index.js
@@ -151,12 +151,12 @@ class MortgageInvestmentCompare extends React.Component {
       shorterOption: {
         mortgageRate: shorter.interestRate / 100,
         mortgageTerm: shorter.term,
-        mortgagePMT: -shorter.pmt
+        mortgagePMT: shorter.pmt
       },
       longerOption: {
         mortgageRate: longer.interestRate / 100,
         mortgageTerm: longer.term,
-        mortgagePMT: -longer.pmt
+        mortgagePMT: longer.pmt
       }
     })
 

--- a/src/components/mortgage-investment-compare/index.js
+++ b/src/components/mortgage-investment-compare/index.js
@@ -13,7 +13,10 @@ import Summary from './summary'
 
 import _ from 'lodash'
 import { FV, PMT } from 'formulajs/lib/financial'
-import { getYearly } from '../../utils/timeSeriesResultsByOption'
+import {
+  getYearly,
+  getPurchasingPower
+} from '../../utils/timeSeriesResultsByOption'
 
 // DEFAULT VALUES
 
@@ -88,23 +91,33 @@ class MortgageInvestmentCompare extends React.Component {
   // Returns future value dynamically depending on mortgage term length.
   calculateFV (option1, option2, state) {
     // TODO: what if terms of option1 and option2 are equal?
-    const inflationAdjustedReturn =
-      (1 + state.investmentRate / COMPOUND_FREQUENCY / 100) /
-        (1 + state.inflation / COMPOUND_FREQUENCY / 100) -
-      1
     if (option1.term > option2.term) {
-      return FV(
-        inflationAdjustedReturn,
-        option1.term * COMPOUND_FREQUENCY,
-        option2.pmt - option1.pmt,
-        0
+      return (
+        FV(
+          state.investmentRate / 100 / COMPOUND_FREQUENCY,
+          option1.term * COMPOUND_FREQUENCY,
+          option2.pmt - option1.pmt,
+          0
+        ) *
+        getPurchasingPower(
+          option1.term,
+          state.inflation / 100,
+          COMPOUND_FREQUENCY
+        )
       )
     } else if (option1.term < option2.term) {
-      return FV(
-        inflationAdjustedReturn,
-        (option2.term - option1.term) * COMPOUND_FREQUENCY,
-        option1.pmt,
-        0
+      return (
+        FV(
+          state.investmentRate / 100 / COMPOUND_FREQUENCY,
+          (option2.term - option1.term) * COMPOUND_FREQUENCY,
+          option1.pmt,
+          0
+        ) *
+        getPurchasingPower(
+          option2.term,
+          state.inflation / 100,
+          COMPOUND_FREQUENCY
+        )
       )
     }
   }

--- a/src/components/mortgage-investment-compare/index.js
+++ b/src/components/mortgage-investment-compare/index.js
@@ -88,16 +88,20 @@ class MortgageInvestmentCompare extends React.Component {
   // Returns future value dynamically depending on mortgage term length.
   calculateFV (option1, option2, state) {
     // TODO: what if terms of option1 and option2 are equal?
+    const inflationAdjustedReturn =
+      (1 + state.investmentRate / COMPOUND_FREQUENCY / 100) /
+        (1 + state.inflation / COMPOUND_FREQUENCY / 100) -
+      1
     if (option1.term > option2.term) {
       return FV(
-        (state.investmentRate - state.inflation) / 100 / COMPOUND_FREQUENCY,
+        inflationAdjustedReturn,
         option1.term * COMPOUND_FREQUENCY,
         option2.pmt - option1.pmt,
         0
       )
     } else if (option1.term < option2.term) {
       return FV(
-        (state.investmentRate - state.inflation) / 100 / COMPOUND_FREQUENCY,
+        inflationAdjustedReturn,
         (option2.term - option1.term) * COMPOUND_FREQUENCY,
         option1.pmt,
         0

--- a/src/components/mortgage-investment-compare/index.js
+++ b/src/components/mortgage-investment-compare/index.js
@@ -150,11 +150,13 @@ class MortgageInvestmentCompare extends React.Component {
       inflationRate: state.inflation / 100,
       shorterOption: {
         mortgageRate: shorter.interestRate / 100,
-        mortgageTerm: shorter.term
+        mortgageTerm: shorter.term,
+        mortgagePMT: -shorter.pmt
       },
       longerOption: {
         mortgageRate: longer.interestRate / 100,
-        mortgageTerm: longer.term
+        mortgageTerm: longer.term,
+        mortgagePMT: -longer.pmt
       }
     })
 

--- a/src/components/mortgage-investment-compare/summary.js
+++ b/src/components/mortgage-investment-compare/summary.js
@@ -132,9 +132,8 @@ const Summary = props => {
             on your house, but your <b>investments</b> are worth{' '}
             <b>
               {toUSD(
-                -props.yearlyResultsByOption.longer[
-                  props.shorterOption.term + 1
-                ].investmentAmount
+                props.yearlyResultsByOption.longer[props.shorterOption.term + 1]
+                  .investmentAmount
               )}
             </b>
             .

--- a/src/components/mortgage-investment-compare/summary.js
+++ b/src/components/mortgage-investment-compare/summary.js
@@ -140,7 +140,7 @@ const Summary = props => {
                 {toUSD(
                   props.yearlyResultsByOption.longer[
                     props.shorterOption.term - 1
-                  ].investmentAmount
+                  ].investmentAmt
                 )}
               </b>
               .

--- a/src/utils/timeSeriesResultsByOption.js
+++ b/src/utils/timeSeriesResultsByOption.js
@@ -10,6 +10,8 @@ export const getMonthly = ({
   const monthlySeries = {}
 
   const budget = Math.abs(shorterOption.mortgagePMT)
+  const monthlyInflationRate = 1 + inflationRate / COMPOUND_FREQUENCY
+  const monthlyInvestmentRate = 1 + investmentRate / COMPOUND_FREQUENCY
 
   /* const getValuesAfterInflation = monthlySeries => {
     const monthlySeriesAfterInflation = {
@@ -48,8 +50,8 @@ export const getMonthly = ({
 
   const shorterList = [
     {
-      budget: budget / (1 + inflationRate / COMPOUND_FREQUENCY),
-      pmt: budget / (1 + inflationRate / COMPOUND_FREQUENCY),
+      budget: budget / monthlyInflationRate,
+      pmt: budget / monthlyInflationRate,
       loanAmt:
         loanAmt * (1 + shorterOption.mortgageRate / COMPOUND_FREQUENCY) +
         shorterOption.mortgagePMT,
@@ -59,16 +61,12 @@ export const getMonthly = ({
   ]
   const longerList = [
     {
-      budget: budget / (1 + inflationRate / COMPOUND_FREQUENCY),
-      pmt:
-        Math.abs(longerOption.mortgagePMT) /
-        (1 + inflationRate / COMPOUND_FREQUENCY),
+      budget: budget / monthlyInflationRate,
+      pmt: Math.abs(longerOption.mortgagePMT) / monthlyInflationRate,
       loanAmt:
         loanAmt * (1 + longerOption.mortgageRate / COMPOUND_FREQUENCY) +
         longerOption.mortgagePMT,
-      investmentPMT:
-        (budget + longerOption.mortgagePMT) /
-        (1 + inflationRate / COMPOUND_FREQUENCY),
+      investmentPMT: (budget + longerOption.mortgagePMT) / monthlyInflationRate,
       investmentAmount: budget + longerOption.mortgagePMT
     }
   ]
@@ -79,9 +77,7 @@ export const getMonthly = ({
     month++
   ) {
     const shorter = {
-      budget:
-        shorterList[month - 1].budget /
-        (1 + inflationRate / COMPOUND_FREQUENCY),
+      budget: shorterList[month - 1].budget / monthlyInflationRate,
       pmt: checkShorterCutoff(month, shorterList[month - 1].budget, true),
       loanAmt:
         shorterList[month - 1].loanAmt *
@@ -93,28 +89,22 @@ export const getMonthly = ({
         false
       ),
       investmentAmount:
-        (shorterList[month - 1].investmentAmount *
-          (1 + investmentRate / COMPOUND_FREQUENCY)) /
-          (1 + inflationRate / COMPOUND_FREQUENCY) +
+        (shorterList[month - 1].investmentAmount * monthlyInvestmentRate) /
+          monthlyInflationRate +
         checkShorterCutoff(month, budget, false)
     }
 
     const longer = {
-      budget:
-        shorterList[month - 1].budget /
-        (1 + inflationRate / COMPOUND_FREQUENCY),
-      pmt: longerList[month - 1].pmt / (1 + inflationRate / COMPOUND_FREQUENCY),
+      budget: shorterList[month - 1].budget / monthlyInflationRate,
+      pmt: longerList[month - 1].pmt / monthlyInflationRate,
       loanAmt:
         longerList[month - 1].loanAmt *
           (1 + longerOption.mortgageRate / COMPOUND_FREQUENCY) +
         longerOption.mortgagePMT,
-      investmentPMT:
-        longerList[month - 1].investmentPMT /
-        (1 + inflationRate / COMPOUND_FREQUENCY),
+      investmentPMT: longerList[month - 1].investmentPMT / monthlyInflationRate,
       investmentAmount:
-        (longerList[month - 1].investmentAmount *
-          (1 + investmentRate / COMPOUND_FREQUENCY)) /
-          (1 + inflationRate / COMPOUND_FREQUENCY) +
+        (longerList[month - 1].investmentAmount * monthlyInvestmentRate) /
+          monthlyInflationRate +
         (budget + longerOption.mortgagePMT)
     }
 

--- a/src/utils/timeSeriesResultsByOption.js
+++ b/src/utils/timeSeriesResultsByOption.js
@@ -81,7 +81,7 @@ export const getMonthly = ({
     }
 
     const longer = {
-      budget: shorterPrevMonth.budget,
+      budget: longerPrevMonth.budget,
       pmt: longerPrevMonth.pmt,
       loanAmt:
         longerPrevMonth.loanAmt * longerOptionMonthlyMortgageRate -
@@ -109,6 +109,8 @@ export const getYearly = ({
   shorterOption,
   longerOption
 }) => {
+  const yearlySeries = {}
+
   const monthlySeries = getMonthly({
     loanAmt,
     investmentRate,
@@ -116,8 +118,6 @@ export const getYearly = ({
     shorterOption,
     longerOption
   })
-
-  const yearlySeries = {}
 
   let budgetResult = 0
   let pmtResult = 0
@@ -138,7 +138,6 @@ export const getYearly = ({
           loanAmt: month.loanAmt || 0,
           investmentAmount: month.investmentAmount || 0
         })
-
         budgetResult = 0
         pmtResult = 0
         investmentPMTResult = 0

--- a/src/utils/timeSeriesResultsByOption.js
+++ b/src/utils/timeSeriesResultsByOption.js
@@ -29,9 +29,11 @@ export const getMonthly = ({
     let condition
 
     if (before) {
-      condition = month <= shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
+      condition =
+        month + 1 <= shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
     } else {
-      condition = month > shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
+      condition =
+        month + 1 > shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
     }
 
     return condition ? value : 0
@@ -59,12 +61,12 @@ export const getMonthly = ({
   ]
 
   for (
-    let month = 1;
-    month <= longerOption.mortgageTerm * COMPOUND_FREQUENCY - 1;
+    let month = 0;
+    month <= longerOption.mortgageTerm * COMPOUND_FREQUENCY;
     month++
   ) {
-    const shorterPrevMonth = shorterList[month - 1]
-    const longerPrevMonth = longerList[month - 1]
+    const shorterPrevMonth = shorterList[month]
+    const longerPrevMonth = longerList[month]
 
     const shorter = {
       budget: shorterPrevMonth.budget,

--- a/src/utils/timeSeriesResultsByOption.js
+++ b/src/utils/timeSeriesResultsByOption.js
@@ -50,11 +50,9 @@ export const getMonthly = ({
     let condition
 
     if (before) {
-      condition =
-        month + 1 <= shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
+      condition = month <= shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
     } else {
-      condition =
-        month + 1 > shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
+      condition = month > shorterOption.mortgageTerm * COMPOUND_FREQUENCY - 1
     }
 
     return condition ? value : 0
@@ -82,12 +80,12 @@ export const getMonthly = ({
   ]
 
   for (
-    let month = 0;
-    month <= longerOption.mortgageTerm * COMPOUND_FREQUENCY;
+    let month = 1;
+    month <= longerOption.mortgageTerm * COMPOUND_FREQUENCY - 1;
     month++
   ) {
-    const shorterPrevMonth = shorterList[month]
-    const longerPrevMonth = longerList[month]
+    const shorterPrevMonth = shorterList[month - 1]
+    const longerPrevMonth = longerList[month - 1]
 
     const shorter = {
       budget: shorterPrevMonth.budget,

--- a/src/utils/timeSeriesResultsByOption.js
+++ b/src/utils/timeSeriesResultsByOption.js
@@ -43,6 +43,7 @@ export function getMonthly ({
       {
         budget: shorterOptionPMT,
         pmt: shorterOptionPMT,
+        investmentPMT: shorterOptionPMT,
         loanAmt: loanAmt + shorterOptionPMT,
         investmentAmount: 0
       }
@@ -51,7 +52,7 @@ export function getMonthly ({
       {
         budget: shorterOptionPMT,
         pmt: longerOptionPMT,
-        investmentPMT: -1 * (longerOptionPMT - shorterOptionPMT),
+        investmentPMT: shorterOptionPMT - longerOptionPMT,
         loanAmt: loanAmt + longerOptionPMT,
         investmentAmount: -1 * (longerOptionPMT - shorterOptionPMT)
       }
@@ -68,6 +69,9 @@ export function getMonthly ({
         shorterOption.mortgageRate,
         investmentRate,
         inflationRate,
+        month >= shorterOption.mortgageTerm * COMPOUND_FREQUENCY
+          ? shorterOptionPMT
+          : 0,
         monthlyResultsByOption.shorter[month - 1]
       )
     )
@@ -76,6 +80,7 @@ export function getMonthly ({
         longerOption.mortgageRate,
         investmentRate,
         inflationRate,
+        shorterOptionPMT - longerOptionPMT,
         monthlyResultsByOption.longer[month - 1]
       )
     )
@@ -88,6 +93,7 @@ function getMonthlyResult (
   mortgageRate,
   investmentRate,
   inflationRate,
+  investmentPMT,
   lastResult
 ) {
   let pmt = lastResult.pmt
@@ -98,13 +104,10 @@ function getMonthlyResult (
     pmt = PMT(mortgageRate / COMPOUND_FREQUENCY, 1, lastResult.loanAmt)
   }
 
-  // Everything else can be invested
-  const investmentPMT = lastResult.budget - pmt
-
   const resultBeforeInflation = {
     budget: lastResult.budget,
     pmt: pmt,
-    investmentPMT: investmentPMT,
+    investmentPMT: lastResult.investmentPMT || 0,
     loanAmt:
       -1 * FV(mortgageRate / COMPOUND_FREQUENCY, 1, pmt, lastResult.loanAmt),
     investmentAmount:

--- a/src/utils/timeSeriesResultsByOption.js
+++ b/src/utils/timeSeriesResultsByOption.js
@@ -35,6 +35,27 @@ export const getMonthly = ({
   const longerOptionMonthlyMortgageRate =
     1 + longerOption.mortgageRate / COMPOUND_FREQUENCY
 
+  const firstMonthShorter = {
+    budget: budget,
+    pmt: budget,
+    loanAmt:
+      loanAmt * shorterOptionMonthlyMortgageRate + shorterOption.mortgagePMT,
+    investmentPMT: 0,
+    investmentAmt: 0
+  }
+
+  const firstMonthLonger = {
+    budget: budget,
+    pmt: Math.abs(longerOption.mortgagePMT),
+    loanAmt:
+      loanAmt * longerOptionMonthlyMortgageRate + longerOption.mortgagePMT,
+    investmentPMT: budget + longerOption.mortgagePMT,
+    investmentAmt: budget + longerOption.mortgagePMT
+  }
+
+  const shorterList = [firstMonthShorter]
+  const longerList = [firstMonthLonger]
+
   const getValuesAfterInflation = termSeries => {
     return termSeries.map((monthData, index) => {
       const monthAfterInflation = {}
@@ -57,27 +78,6 @@ export const getMonthly = ({
 
     return condition ? value : 0
   }
-
-  const shorterList = [
-    {
-      budget: budget,
-      pmt: budget,
-      loanAmt:
-        loanAmt * shorterOptionMonthlyMortgageRate + shorterOption.mortgagePMT,
-      investmentPMT: 0,
-      investmentAmt: 0
-    }
-  ]
-  const longerList = [
-    {
-      budget: budget,
-      pmt: Math.abs(longerOption.mortgagePMT),
-      loanAmt:
-        loanAmt * longerOptionMonthlyMortgageRate + longerOption.mortgagePMT,
-      investmentPMT: budget + longerOption.mortgagePMT,
-      investmentAmt: budget + longerOption.mortgagePMT
-    }
-  ]
 
   for (
     let month = 1;


### PR DESCRIPTION
Please read comments below. I try to walk you over the investment amount issue. 

There are a couple of outstanding issues that we need to resolve. Hopefully we can work on it together. You'll probably have to pull the branch and open the table to see these:

1. ~~Shorter term now shows investment payments before the loan is paid for. This was a side effect of fixing the investment amount issue. We should only show investment payments after the 15th year, with the first payment adjusted to inflation after 15 years if that makes sense.~~

![image](https://user-images.githubusercontent.com/9560798/65282113-fccbe700-dae8-11e9-982c-62ddcb6bb975.png)

2. ~~The final investment amounts are still off by very little. I think this is more of a timing issue in our calculations as opposed to an inflation issue. This timing issue seems to be affecting everything, the loan, the mortgage payment etc. We are off by a few months for some reason.~~
