### PR TITLE
Small design improvements

### DIFF
--- a/src/components/mortgage-investment-compare/accordion.js
+++ b/src/components/mortgage-investment-compare/accordion.js
@@ -32,7 +32,7 @@ class Accordion extends Component {
           )}
         </a>
         <Collapse className='pl-3 py-2' isOpen={this.state.collapse}>
-          {this.props.children}
+          <small>{this.props.children}</small>
         </Collapse>
       </div>
     )

--- a/src/components/mortgage-investment-compare/amortization-table.js
+++ b/src/components/mortgage-investment-compare/amortization-table.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Table } from 'reactstrap'
 import { GRAY_300, GRAY, GREEN_300 } from '../../assets/colors'
-import styled, { css, cx } from 'react-emotion'
+import styled, { css } from 'react-emotion'
 
 import { toUSD } from '../../utils/numberFormat'
 

--- a/src/components/mortgage-investment-compare/amortization-table.js
+++ b/src/components/mortgage-investment-compare/amortization-table.js
@@ -2,54 +2,67 @@ import React from 'react'
 
 import { Table } from 'reactstrap'
 import { GRAY_300, GRAY, GREEN_300 } from '../../assets/colors'
-import { css, cx } from 'react-emotion'
+import styled, { css, cx } from 'react-emotion'
 
 import { toUSD } from '../../utils/numberFormat'
 
-const amortizationTable = css`
-  thead tr:first-of-type th {
-    font-size: 1rem;
-  }
+const tableDivider = css`
+  border-left-width: thick;
+  border-left-color: ${GRAY}};
+`
+const fixedTableLayout = css`
+  display: table;
+  width: 100%;
+  table-layout: fixed; /* even columns width , fix width of table too*/
+`
+const tableFontSizeAlign = css`
+  text-align: center;
+  font-size: 0.75rem;
+`
 
-  thead,
-  tbody tr {
-    display: table;
-    width: 100%;
-    table-layout: fixed; /* even columns width , fix width of table too*/
-  }
-  thead {
-    width: calc(
-      100% - 1em
-    ); /* scrollbar is average 1em/16px width, remove it from thead width */
-  }
+const Thead = styled('thead')`
+  ${fixedTableLayout}
 
-  tbody {
-    display: block;
-    height: 40rem;
-    overflow: auto;
-  }
+  width: calc(
+    100% - 1em
+  ); /* scrollbar is average 1em/16px width, remove it from thead width */
+`
+const Tbody = styled('tbody')`
+  ${tableFontSizeAlign}
 
-  th,
-  tbody {
-    text-align: center;
-    font-size: 0.75rem;
-  }
+  display: block;
+  height: 45rem;
+  overflow: auto;
+`
+const Th = styled('th')`
+  ${tableFontSizeAlign}
 
-  th:first-of-type,
-  td:first-of-type {
+  :first-of-type {
     white-space: nowrap;
-  }
-
-  th:first-of-type {
     border: 0;
   }
 
-  th:nth-child(6),
-  td:nth-child(6) {
-    border-left-width: thick;
-    border-left-color: ${GRAY}};
+  :nth-child(6) {
+    ${tableDivider}
   }
 `
+const Tr = styled('tr')`
+  ${fixedTableLayout}
+
+  :first-of-type th {
+    font-size: 1rem;
+  }
+`
+const Td = styled('td')`
+  :first-of-type {
+    white-space: nowrap;
+  }
+
+  :nth-child(6) {
+    ${tableDivider}
+  }
+`
+
 // checks if the table row being passed corresponds to the final year of either term
 const checkLoanTerms = (year, option1, option2) => {
   return year + 1 === option1.term || year + 1 === option2.term
@@ -121,32 +134,32 @@ const AmortizationTable = props => {
   return (
     <div>
       <h4>Yearly Breakdown</h4>
-      <Table bordered responsive className={cx(amortizationTable, 'mt-3')}>
-        <thead>
-          <tr>
-            <th colSpan='1' />
-            <th colSpan='4'>{props.shorterOption.term} year</th>
-            <th colSpan='4'>{props.longerOption.term} year</th>
-          </tr>
-          <tr>
-            <th colSpan='1' />
-            <th>Mortgage Payment</th>
-            <th>Investment Payment</th>
-            <th>Loan Amount</th>
-            <th>Investment Amount</th>
-            <th>Mortgage Payment</th>
-            <th>Investment Payment</th>
-            <th>Loan Amount</th>
-            <th>Investment Amount</th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table bordered responsive className='mt-3'>
+        <Thead>
+          <Tr>
+            <Th colSpan='1' />
+            <Th colSpan='4'>{props.shorterOption.term} year</Th>
+            <Th colSpan='4'>{props.longerOption.term} year</Th>
+          </Tr>
+          <Tr>
+            <Th colSpan='1' />
+            <Th>Mortgage Payment</Th>
+            <Th>Investment Payment</Th>
+            <Th>Loan Amount</Th>
+            <Th>Investment Amount</Th>
+            <Th>Mortgage Payment</Th>
+            <Th>Investment Payment</Th>
+            <Th>Loan Amount</Th>
+            <Th>Investment Amount</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
           {props.yearlyResultsByOption.shorter.map((_r, year) => {
             const shorter = props.yearlyResultsByOption.shorter[year]
             const longer = props.yearlyResultsByOption.longer[year]
 
             return (
-              <tr
+              <Tr
                 key={'row' + year}
                 className={highlightTableCells(
                   year,
@@ -157,19 +170,19 @@ const AmortizationTable = props => {
                   hoverTableCells(year, props.option1, props.option2)
                 }
               >
-                <td>Year {year + 1}</td>
-                <td>{toUSD(shorter.pmt)}</td>
-                <td>{toUSD(shorter.investmentPMT)}</td>
-                <td>{toUSD(shorter.loanAmt)}</td>
-                <td>{toUSD(shorter.investmentAmt)}</td>
-                <td>{toUSD(longer.pmt)}</td>
-                <td>{toUSD(longer.investmentPMT)}</td>
-                <td>{toUSD(longer.loanAmt)}</td>
-                <td>{toUSD(longer.investmentAmt)}</td>
-              </tr>
+                <Td>Year {year + 1}</Td>
+                <Td>{toUSD(shorter.pmt)}</Td>
+                <Td>{toUSD(shorter.investmentPMT)}</Td>
+                <Td>{toUSD(shorter.loanAmt)}</Td>
+                <Td>{toUSD(shorter.investmentAmt)}</Td>
+                <Td>{toUSD(longer.pmt)}</Td>
+                <Td>{toUSD(longer.investmentPMT)}</Td>
+                <Td>{toUSD(longer.loanAmt)}</Td>
+                <Td>{toUSD(longer.investmentAmt)}</Td>
+              </Tr>
             )
           })}
-        </tbody>
+        </Tbody>
       </Table>
     </div>
   )

--- a/src/components/mortgage-investment-compare/index.js
+++ b/src/components/mortgage-investment-compare/index.js
@@ -201,8 +201,9 @@ class MortgageInvestmentCompare extends React.Component {
         </Col>
         <Col xs='8'>
           <Button
-            className='float-right mb-3'
+            className='float-right mb-4 ml-4'
             outline
+            size='lg'
             color='success'
             onClick={this.toggleShowTable}
           >

--- a/src/components/mortgage-investment-compare/input-card.js
+++ b/src/components/mortgage-investment-compare/input-card.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import styled from 'react-emotion'
 
 import Accordion from './accordion'
 import {
@@ -103,7 +102,7 @@ const InputCard = props => {
             versus 30-year mortgages.
           </Accordion>
           <Accordion
-            title={`What happens when after you’re done paying off the ${
+            title={`What happens after you’re done paying off the ${
               props.shorterOption.term
             }-year mortgage?`}
           >
@@ -165,7 +164,7 @@ const InputCard = props => {
             <a href='https://www.bankrate.com/glossary/a/apr/'>Bankrate</a>{' '}
             provides a more in-depth explanation.
           </Accordion>
-          <Accordion title='Fixed vs Variable Interest Rates'>
+          <Accordion title='Fixed vs. Variable Interest Rates'>
             This tool assumes your mortgage interest rate is fixed.{' '}
             <a href='https://www.valuepenguin.com/loans/fixed-vs-variable-interest-rates'>
               Value Penguin

--- a/src/components/mortgage-investment-compare/input-card.js
+++ b/src/components/mortgage-investment-compare/input-card.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'react-emotion'
 
 import Accordion from './accordion'
 import {
@@ -31,9 +32,9 @@ const InputCard = props => {
   return (
     <Card className='p-4'>
       <Form>
-        <FormGroup>
+        <FormGroup className='mb-3'>
           <label>How much is your loan?</label>
-          <InputGroup>
+          <InputGroup className='my-2'>
             <InputGroupAddon addonType='prepend'>
               <InputGroupText>$</InputGroupText>
             </InputGroupAddon>
@@ -55,12 +56,15 @@ const InputCard = props => {
             has a great tool to help you determine how much you can afford.
           </Accordion>
         </FormGroup>
-        <FormGroup>
+        <hr />
+        <FormGroup className='mb-3'>
           <label>Loan Term</label>
           <Row form>
             <Col>
-              <small>Mortgage Option 1</small>
-              <InputGroup>
+              <small>
+                <b>Mortgage Option 1</b>
+              </small>
+              <InputGroup className='my-2'>
                 <Input
                   name='options.option1.term'
                   placeholder='Loan Term'
@@ -74,8 +78,10 @@ const InputCard = props => {
               </InputGroup>
             </Col>
             <Col>
-              <small>Mortgage Option 2</small>
-              <InputGroup>
+              <small>
+                <b>Mortgage Option 2</b>
+              </small>
+              <InputGroup className='my-2'>
                 <Input
                   name='options.option2.term'
                   placeholder='Loan Term'
@@ -115,12 +121,15 @@ const InputCard = props => {
             mortgage.
           </Accordion>
         </FormGroup>
-        <FormGroup>
+        <hr />
+        <FormGroup className='mb-3'>
           <label>Annual Percentage Rate (APR) & Interest</label>
           <Row form>
             <Col>
-              <small>Mortgage Option 1</small>
-              <InputGroup>
+              <small>
+                <b>Mortgage Option 1</b>
+              </small>
+              <InputGroup className='my-2'>
                 <Input
                   name='options.option1.interestRate'
                   placeholder='APR'
@@ -134,8 +143,10 @@ const InputCard = props => {
               </InputGroup>
             </Col>
             <Col>
-              <small>Mortgage Option 2</small>
-              <InputGroup>
+              <small>
+                <b>Mortgage Option 2</b>
+              </small>
+              <InputGroup className='my-2'>
                 <Input
                   name='options.option2.interestRate'
                   placeholder='APR'
@@ -162,9 +173,10 @@ const InputCard = props => {
             has a great article about how fixed and variable rates work.
           </Accordion>
         </FormGroup>
-        <FormGroup>
+        <hr />
+        <FormGroup className='mb-3'>
           <label>Return on Investment (ROI)</label>
-          <InputGroup>
+          <InputGroup className='my-2'>
             <Input
               name='investmentRate'
               placeholder='ROI'
@@ -233,9 +245,10 @@ const InputCard = props => {
             provides a more in-depth analysis on this topic.
           </Accordion>
         </FormGroup>
-        <FormGroup>
+        <hr />
+        <FormGroup className='mb-3'>
           <label>Inflation</label>
-          <InputGroup>
+          <InputGroup className='my-2'>
             <Input
               name='inflation'
               placeholder='Inflation'

--- a/src/components/mortgage-investment-compare/summary.js
+++ b/src/components/mortgage-investment-compare/summary.js
@@ -38,7 +38,7 @@ function ScenarioCol (props) {
  */
 function BoxCol (props) {
   return (
-    <Col className={`p-4 text-center ${props.isBestOption && emphasize}`}>
+    <Col className={`p-4 mt-2 text-center ${props.isBestOption && emphasize}`}>
       <div className={cx(box(props.isBestOption), 'p-4')}>
         <b>{props.option.term}yr</b>
       </div>

--- a/src/components/mortgage-investment-compare/summary.js
+++ b/src/components/mortgage-investment-compare/summary.js
@@ -71,9 +71,9 @@ const Summary = props => {
             {props.bestOption.term} year mortgage
           </b>
           . <b>{toUSD(props.optCost)}</b> is the difference between your{' '}
-          {props.shorterOption.term} year investment total (
+          {props.shorterOption.term} year final portfolio value (
           <b>{toUSD(props.shorterOption.fv)}</b>) and your{' '}
-          {props.longerOption.term} year investment total (
+          {props.longerOption.term} year final portfolio value (
           <b>{toUSD(props.longerOption.fv)}</b>).
         </p>
         <Row noGutters className='my-4'>


### PR DESCRIPTION
#25 and other small design improvements. Also addressed refactoring of table's css suggested in #46 

Open both images on 2 different tabs and switch for easier comparison.

Before: 

![image](https://user-images.githubusercontent.com/9560798/65529629-55b1cb80-deab-11e9-8dbf-e9d1aae3827a.png)

After:

![image](https://user-images.githubusercontent.com/9560798/65529697-7bd76b80-deab-11e9-9557-a85040371a58.png)
